### PR TITLE
Added openq-bot to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,21 @@ services:
       - ./OpenQ-Bounty-Actions-Autotask:/app
     env_file:
       - ./OpenQ-Bounty-Actions-Autotask/.env
+  openq-bot:
+    container_name: openq-bot
+    depends_on:
+      - openq-bounty-actions-autotask
+      - openq-contracts
+    build:
+      dockerfile: Dockerfile.dev
+      context: ./OpenQ-Bot
+    ports:
+      - "3006:3006"
+    volumes:
+      - /app/node_modules
+      - ./OpenQ-Bot:/app
+    env_file:
+      - ./OpenQ-Bot/.env    
   openq-frontend:
     container_name: openq-frontend
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       - openq-bounty-actions-autotask
       - openq-contracts
     build:
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
       context: ./OpenQ-Bot
     ports:
       - "3006:3006"


### PR DESCRIPTION
Added openq-bot to docker compose. Please double check this, it works, but I was just copying the other parts of the docker compose and modifying them.
Also, before integrating this, please pull the latest Bot, Event-Listener, and Bounty-Actions-Autotask.